### PR TITLE
Fix mongorestore --oplogReplay

### DIFF
--- a/mongorestore/oplog.go
+++ b/mongorestore/oplog.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const oplogMaxCommandSize = 1024 * 1024 * 16.5
+const oplogMaxCommandSize = 1024 * 1024 * 15
 
 // RestoreOplog attempts to restore a MongoDB oplog.
 func (restore *MongoRestore) RestoreOplog() error {


### PR DESCRIPTION
Running `mongorestore` with the `--oplogReplay` command line option fails if the `dump/oplog.bson` file is larger than 16MB. It prints the following error message.

> Failed: restore error: error applying oplog: applyOps: EOF

I think the problem is on [line 17 of mongorestore/oplog.go](https://github.com/mongodb/mongo-tools/blob/r3.0.3/mongorestore/oplog.go#L17). The `oplogMaxCommandSize` constant is defined as 16.5 MB, even though the MongoDB maximum document size is 16 MB!?! This causes an exception on the server side which closes the `applyOps` command cursor, hence the EOF message.

I'm not sure why, but setting `oplogMaxCommandSize` to `1024 * 1024 * 16` did not fix the problem for me. But setting it to `1024 * 1024 * 15` made the bug go away.

There is also a [report of this bug on StackOverflow](http://stackoverflow.com/questions/30012055/).